### PR TITLE
Improve contrast for selected item in overlay list

### DIFF
--- a/stylesheets/overlays.less
+++ b/stylesheets/overlays.less
@@ -32,6 +32,7 @@
       }
 
       &.selected {
+        background-color: darken(@overlay-background-color, 3%);
         .status.icon {
           color: @text-color-selected;
         }


### PR DESCRIPTION
In my opinion it's currently very hard to see which item is selected in the overlay (the ones that ⌘-P/⌘-T open), so I added a background color which makes it way easier to see it.

Before:
![overlays_less_-__users_rmehner__atom_packages_atom-soda-dark-ui](https://f.cloud.github.com/assets/82050/2325083/9611d63c-a3d0-11e3-9f4c-27a29ffb5133.png)

After:
![overlays_less_-__users_rmehner__atom_packages_atom-soda-dark-ui](https://f.cloud.github.com/assets/82050/2325095/c195e910-a3d0-11e3-88e9-3982b7bb3aeb.png)
