### PR TITLE
Fix: Selection highlighting missing in autocomplete

### DIFF
--- a/stylesheets/lists.less
+++ b/stylesheets/lists.less
@@ -49,7 +49,7 @@
   // We want to highlight the background of the list items because we dont
   // know their size.
   li.selected {
-    background-color: @background-color-selected;
+    background: @background-color-selected;
     &:before{ display: none; }
   }
 


### PR DESCRIPTION
This commit fixes issue #7
