### PR TITLE
Fix for atom 1.18.0

### DIFF
--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -21,7 +21,7 @@
 @background-color-warning: #ffaa2c;
 @background-color-error: #c00;
 @background-color-highlight: rgba(255, 255, 255, 0.07);
-@background-color-selected: linear-gradient(rgba(78, 78, 78, 1.0), rgba(67, 67, 67, 1.0));
+@background-color-selected: rgba(73, 73, 73, 1.0);
 
 @app-background-color: #333;
 

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -1,3 +1,6 @@
+// Workaround for https://github.com/facebook-atom/atom-ide-ui/issues/14
+@import "syntax-variables";
+
 // Colors
 
 @text-color: #aaa;


### PR DESCRIPTION
The theme breaks atom 1.18.0. When loaded, the ui-variables.less file causes an exception when the atom theme engine trys to mix the text color (RGBA or HSL) with the background color (a linear gradient).

This patch works around the problem by changing the linear gradient to a flat color.